### PR TITLE
fixed short trace and outside the class error

### DIFF
--- a/src/lf4php/LocationLogger.php
+++ b/src/lf4php/LocationLogger.php
@@ -53,9 +53,15 @@ abstract class LocationLogger implements Logger
         } else {
             $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $backtraceLevel + 1);
         }
-        return array_key_exists($backtraceLevel, $trace)
-            ? $trace[$backtraceLevel]['class']
-            : $trace[$backtraceLevel - 1]['file'];
+
+        $traceCount = count($trace);
+        if ($backtraceLevel <= $traceCount) {
+            return !empty($trace[$backtraceLevel]['class'])
+                ? $trace[$backtraceLevel]['class']
+                : $trace[$backtraceLevel -1 ]['file'];
+        } else {
+            return $trace[$traceCount - 1]['file'];
+        }
     }
 
     protected function getShortLocation($backtraceLevel = self::DEFAULT_BACKTRACE_LEVEL)


### PR DESCRIPTION
I got an exception if it was too short stack trace or if the logger not call inside of class.
The problem experienced with lf4php-monolog.
Try the other library, because I have not tried.

The way for error:

``` php
$monologFactory = new \lf4php\monolog\MonologLoggerFactory();
$monologFactory->registerMonologLogger($monolog); // <-- instance of monolog
LoggerFactory::setILoggerFactory($monologFactory);
// call
LoggerFactory::getLogger('api')->error('Example Error!');
```

Thanks.
